### PR TITLE
Exit with error code to signify error occurred

### DIFF
--- a/internal/cmd/ksl/main.go
+++ b/internal/cmd/ksl/main.go
@@ -32,6 +32,7 @@ func main() {
 		err := compileToIL(*toCompile, output)
 		if err != nil {
 			fmt.Printf("Failed to compile: " + err.Error())
+			os.Exit(1)
 		}
 		return
 	}
@@ -39,6 +40,7 @@ func main() {
 	err := build(flag.Args(), output)
 	if err != nil {
 		fmt.Printf("Error: %s\n", err.Error())
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Was testing out the build pipeline with invalid ksl files and noticed the pipeline wouldn't fail even if an error had occurred. Upon testing the exit code when an error occurs is 0, which indicates success. Setting the exit code on an error to 1 should help prevent invalid schema changes from being passed.

Before changes:
```
Error: : symbol already exists
echo $?
0
```

After:
```
Error: : symbol already exists
echo $?
1
```