### PR TITLE
Adds check to error if subrelation on type does not exist

### DIFF
--- a/internal/semantic/References.go
+++ b/internal/semantic/References.go
@@ -131,6 +131,13 @@ func (r *TypeReference) Resolve(fromType *Type) error {
 		return err
 	}
 
+	if r.subRelation != "" {
+		_, ok := resolvedType.relations.Get(r.subRelation)
+		if !ok {
+			return fmt.Errorf("relation %s not found on type %s.%s %w", r.subRelation, resolvedType.namespace.name, resolvedType.name, ErrSymbolNotFound)
+		}
+	}
+
 	r.instance = resolvedType
 	return nil
 }

--- a/internal/semantic/Relation_test.go
+++ b/internal/semantic/Relation_test.go
@@ -84,3 +84,28 @@ func TestAssertReferenceRelationExpressionToZanzibarFailsIfSubRelationIsTypo(t *
 	_, err = schema.ToZanzibar()
 	assert.ErrorIs(t, err, ErrSymbolNotFound)
 }
+
+func TestAssertReferenceRelationExpressionToZanzibarSucceedsIfSubRelationIsValid(t *testing.T) {
+	schema := NewSchema()
+	namespace := NewNamespace("test_namespace", []string{})
+	principal := NewType("principal", namespace, VisibilityPublic)
+	group := NewType("group", namespace, VisibilityPublic)
+
+	principalTypeReference := NewTypeReference("", "principal", "", false)
+	groupTypeReference := NewTypeReference("", "group", "member", false)
+
+	typeReferences := []*TypeReference{principalTypeReference, groupTypeReference}
+
+	setrel := NewSelfRelationExpression(typeReferences, CardinalityAny)
+
+	rel, err := NewRelation("member", group, VisibilityPublic, setrel, nil)
+	assert.NoError(t, err)
+
+	group.AddRelation(rel)
+	namespace.AddType(principal)
+	namespace.AddType(group)
+	schema.AddNamespace(namespace)
+
+	_, err = schema.ToZanzibar()
+	assert.NoError(t, err)
+}

--- a/internal/semantic/Relation_test.go
+++ b/internal/semantic/Relation_test.go
@@ -59,3 +59,28 @@ func TestAssertReferenceRelationExpressionToZanzibarSucceedsIfSubRelationIsNilAn
 	_, err = schema.ToZanzibar()
 	assert.ErrorIs(t, err, ErrSymbolNotFound)
 }
+
+func TestAssertReferenceRelationExpressionToZanzibarFailsIfSubRelationIsTypo(t *testing.T) {
+	schema := NewSchema()
+	namespace := NewNamespace("test_namespace", []string{})
+	principal := NewType("principal", namespace, VisibilityPublic)
+	group := NewType("group", namespace, VisibilityPublic)
+
+	principalTypeReference := NewTypeReference("", "principal", "", false)
+	groupTypeReference := NewTypeReference("", "group", "membr", false)
+
+	typeReferences := []*TypeReference{principalTypeReference, groupTypeReference}
+
+	setrel := NewSelfRelationExpression(typeReferences, CardinalityAny)
+
+	rel, err := NewRelation("member", group, VisibilityPublic, setrel, nil)
+	assert.NoError(t, err)
+
+	group.AddRelation(rel)
+	namespace.AddType(principal)
+	namespace.AddType(group)
+	schema.AddNamespace(namespace)
+
+	_, err = schema.ToZanzibar()
+	assert.ErrorIs(t, err, ErrSymbolNotFound)
+}


### PR DESCRIPTION
Adds code that will check if the subrelation listed on a type exists, and errors out if it does not.