### PR TITLE
Throw error when parsing

### DIFF
--- a/internal/semantic/Relation.go
+++ b/internal/semantic/Relation.go
@@ -170,7 +170,7 @@ func (e *ReferenceRelationExpression) ToZanzibar(r *Relation) (*core.SetOperatio
 
 		subrelation, ok := t.instance.relations.Get(*e.subrelation)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("relation %s not found on type %s.%s %w", *e.subrelation, e.relation, *e.subrelation, ErrSymbolNotFound)
 		}
 
 		if !subrelation.VisibleTo(r.inType) {

--- a/pkg/ksl/compiler_test.go
+++ b/pkg/ksl/compiler_test.go
@@ -1,0 +1,23 @@
+package ksl
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBad(t *testing.T) {
+	ns, err := Compile(strings.NewReader(`
+version 0.1
+namespace rbac
+
+public type principal {}
+
+public type group {
+    relation member: [Any principal or group.membr]
+}`))
+
+	assert.NoError(t, err)
+	assert.Equal(t, "rbac", ns.Name)
+}


### PR DESCRIPTION
Creates an error handler that handles incorrect characters or missing tokens and exits