### PR TITLE
RHCLOUD-38624 Alphabetize all members in the final output schema

### DIFF
--- a/internal/semantic/Relation_test.go
+++ b/internal/semantic/Relation_test.go
@@ -22,8 +22,8 @@ func TestAssertSelfRelationExpressionToZanzibarSuccess(t *testing.T) {
 	the_type.AddRelation(rel)
 
 	schemaDef, err := schema.ToZanzibar()
-	assert.Equal(t, the_type.namespace.name+"/"+the_type.name, schemaDef[0].GetName())
-	assert.Equal(t, other_type.namespace.name+"/"+other_type.name, schemaDef[1].GetName())
+	assert.Equal(t, other_type.namespace.name+"/"+other_type.name, schemaDef[0].GetName())
+	assert.Equal(t, the_type.namespace.name+"/"+the_type.name, schemaDef[1].GetName())
 	assert.NoError(t, err)
 }
 

--- a/internal/util/ordered_map.go
+++ b/internal/util/ordered_map.go
@@ -1,6 +1,9 @@
 package util
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"slices"
+)
 
 type OrderedMap[T any] struct {
 	names  []string
@@ -29,7 +32,11 @@ func (m *OrderedMap[T]) Get(name string) (T, bool) {
 }
 
 func (m *OrderedMap[T]) Iterate(f func(string, T) error) error {
-	for _, name := range m.names {
+	sorted_names := make([]string, len(m.names))
+	copy(sorted_names, m.names)
+	slices.Sort(sorted_names)
+
+	for _, name := range sorted_names {
 		value := m.values[name]
 
 		if err := f(name, value); err != nil {

--- a/internal/util/ordered_map_test.go
+++ b/internal/util/ordered_map_test.go
@@ -11,11 +11,11 @@ import (
 func TestOrderedMapIteratesInInsertionOrder(t *testing.T) {
 	m := NewOrderedMap[int]()
 
-	m.Add("one", 1)
-	m.Add("two", 2)
-	m.Add("three", 3)
-	m.Add("four", 4)
-	m.Add("five", 5)
+	m.Add("2", 2)
+	m.Add("1", 1)
+	m.Add("4", 4)
+	m.Add("5", 5)
+	m.Add("3", 3)
 
 	actual := []int{}
 	err := m.Iterate(func(s string, i int) error {
@@ -53,9 +53,9 @@ func TestOrderedMapReturnsErrorFromIterate(t *testing.T) {
 
 func TestOrderedMapSerializationRoundTrip(t *testing.T) {
 	m := NewOrderedMap[int]()
-	m.Add("one", 1)
-	m.Add("two", 2)
-	m.Add("three", 3)
+	m.Add("1", 1)
+	m.Add("3", 3)
+	m.Add("2", 2)
 
 	holder := mapHolder{OM: m}
 	data, err := json.Marshal(holder)


### PR DESCRIPTION
This will ensure diff comprehensibility even when types and members come from different sources (ex: something from a generated KSIL module being moved to a hand-written KSL module) and is critical for being able to quickly verify that changes are not breaking. Consider the following diff after making a purely additive change by adding the HBI schema defined [here](https://github.com/RedHatInsights/rbac-config/pull/593/files), which is visibly purely additive (and clear what's being added - it stands out, for example, that there's a new assignable permission - t_inventory_all_write - that may not be intended):
```
0a1,7
> definition hbi/host {
>       permission update = t_workspace->inventory_host_update
>       permission view = t_workspace->inventory_host_view
>       permission workspace = t_workspace
>       relation t_workspace: rbac/workspace
> }
> 
22a30,31
>       permission inventory_host_update = t_binding->inventory_host_update
>       permission inventory_host_view = t_binding->inventory_host_view
199a209,210
>       permission inventory_all_write = t_inventory_all_write
>       relation t_inventory_all_write: rbac/principal:*
205a217,218
>       permission inventory_host_update = inventory_hosts_write + inventory_hosts_all + inventory_all_write + inventory_all_all + all_all_all + t_child->inventory_host_update
>       permission inventory_host_view = inventory_hosts_read + inventory_hosts_all + inventory_all_read + inventory_all_all + all_all_all + t_child->inventory_host_view
390a404,405
>       permission inventory_host_update = (subject & t_role->inventory_host_update)
>       permission inventory_host_view = (subject & t_role->inventory_host_view)
417a433,434
>       permission inventory_host_update = t_binding->inventory_host_update + t_platform->inventory_host_update
>       permission inventory_host_view = t_binding->inventory_host_view + t_platform->inventory_host_view
442a460,461
>       permission inventory_host_update = t_binding->inventory_host_update + t_parent->inventory_host_update
>       permission inventory_host_view = t_binding->inventory_host_view + t_parent->inventory_host_view
```

Without this change, it would have looked like this, with multiple adds and deletes, which is not as clearly safe, nor is it as clear what actually happened:
```
0a1,7
> definition hbi/host {
>       permission workspace = t_workspace
>       relation t_workspace: rbac/workspace
>       permission view = t_workspace->inventory_host_view
>       permission update = t_workspace->inventory_host_update
> }
> 
17a25,26
>       permission inventory_host_view = t_binding->inventory_host_view
>       permission inventory_host_update = t_binding->inventory_host_update
42a52,53
>       permission inventory_host_view = t_binding->inventory_host_view + t_platform->inventory_host_view
>       permission inventory_host_update = t_binding->inventory_host_update + t_platform->inventory_host_update
74a86,99
>       permission inventory_all_all = t_inventory_all_all
>       relation t_inventory_all_all: rbac/principal:*
>       permission inventory_hosts_all = t_inventory_hosts_all
>       relation t_inventory_hosts_all: rbac/principal:*
>       permission inventory_all_read = t_inventory_all_read
>       relation t_inventory_all_read: rbac/principal:*
>       permission inventory_hosts_read = t_inventory_hosts_read
>       relation t_inventory_hosts_read: rbac/principal:*
>       permission inventory_host_view = inventory_hosts_read + inventory_hosts_all + inventory_all_read + inventory_all_all + all_all_all + t_child->inventory_host_view
>       permission inventory_all_write = t_inventory_all_write
>       relation t_inventory_all_write: rbac/principal:*
>       permission inventory_hosts_write = t_inventory_hosts_write
>       relation t_inventory_hosts_write: rbac/principal:*
>       permission inventory_host_update = inventory_hosts_write + inventory_hosts_all + inventory_all_write + inventory_all_all + all_all_all + t_child->inventory_host_update
120a146,151
>       permission inventory_groups_read = t_inventory_groups_read
>       relation t_inventory_groups_read: rbac/principal:*
>       permission inventory_groups_write = t_inventory_groups_write
>       relation t_inventory_groups_write: rbac/principal:*
>       permission inventory_groups_all = t_inventory_groups_all
>       relation t_inventory_groups_all: rbac/principal:*
255,270d285
<       permission inventory_all_read = t_inventory_all_read
<       relation t_inventory_all_read: rbac/principal:*
<       permission inventory_all_all = t_inventory_all_all
<       relation t_inventory_all_all: rbac/principal:*
<       permission inventory_groups_read = t_inventory_groups_read
<       relation t_inventory_groups_read: rbac/principal:*
<       permission inventory_groups_write = t_inventory_groups_write
<       relation t_inventory_groups_write: rbac/principal:*
<       permission inventory_groups_all = t_inventory_groups_all
<       relation t_inventory_groups_all: rbac/principal:*
<       permission inventory_hosts_read = t_inventory_hosts_read
<       relation t_inventory_hosts_read: rbac/principal:*
<       permission inventory_hosts_write = t_inventory_hosts_write
<       relation t_inventory_hosts_write: rbac/principal:*
<       permission inventory_hosts_all = t_inventory_hosts_all
<       relation t_inventory_hosts_all: rbac/principal:*
419a435,436
>       permission inventory_host_view = (subject & t_role->inventory_host_view)
>       permission inventory_host_update = (subject & t_role->inventory_host_update)
444a462,463
>       permission inventory_host_view = t_binding->inventory_host_view + t_parent->inventory_host_view
>       permission inventory_host_update = t_binding->inventory_host_update + t_parent->inventory_host_update
```
